### PR TITLE
Configure Read the Docs to pull from source repos and build site

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,24 @@
+# This is a Read the Docs configuration file for Sphinx projects.
+# References: https://docs.readthedocs.io/en/stable/config-file/v2.html
+version: 2
+
+# Indicate which OS and Python version we want Read the Docs to use
+# when compiling our documentation.
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+  # Override parts of the standard Read the Docs build process.
+  # Reference: https://docs.readthedocs.io/en/stable/build-customization.html
+  jobs:
+    pre_build:
+      - python compose.py && cd docs && make html
+
+# Tell Sphinx where our `conf.py` file resides.
+sphinx:
+  configuration: docs/conf.py
+
+# Tell Sphinx where our Python package requirements list resides.
+python:
+  install:
+    - requirements: requirements.txt


### PR DESCRIPTION
This will be my first attempt at using the `.readthedocs.yaml` file to do this. If this doesn't work, I'll resort to implementing the redirects via the Read the Docs web GUI.